### PR TITLE
Start explorer with custom port

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -7,6 +7,11 @@ cd docker-compose
 docker-compose pull
 NODE_ENDPOINT=http://<node_endpoint> docker-compose up
 ```
+The explorer runs on port `80` by default, if you want to use a custom port e.g 26000, set the `PORT` environment variable and the explorer will be accessible via http://localhost:26000.
+
+```bash
+NODE_ENDPOINT=http://<host_endpoint> PORT=26000 docker-compose up
+```
 
 Note that if setting `NODE_ENDPOINT` to a local Ethereum instance, you may need to use the IP address associated with the Docker bridged interface. 
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -10,7 +10,7 @@ NODE_ENDPOINT=http://<node_endpoint> docker-compose up
 The explorer runs on port `80` by default, if you want to use a custom port e.g 26000, set the `PORT` environment variable and the explorer will be accessible via http://localhost:26000.
 
 ```bash
-NODE_ENDPOINT=http://<host_endpoint> PORT=26000 docker-compose up
+NODE_ENDPOINT=http://localhost:8585 PORT=26000 docker-compose up -d
 ```
 
 Note that if setting `NODE_ENDPOINT` to a local Ethereum instance, you may need to use the IP address associated with the Docker bridged interface. 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     image: web3labs/epirus-free-web:latest
     environment:
       - API_URL=/api
+      - DISPLAY_NETWORK_TAB=disabled
     depends_on:
       - api
     networks:
@@ -48,7 +49,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf
       - ./5xx.html:/www/error_pages/5xx.html
     ports:
-      - 80:80
+      - ${PORT:-80}:80
     depends_on:
       - api
       - web


### PR DESCRIPTION
Sirato explorer currently starts on a default port of `80` when the docker-compose `NODE_ENDPOINT=http://host.docker.internal:8545  docker-compose up` is used to start the explorer.

This PR allows the port to be overridden by the `PORT` variable. 
For instance, running `NODE_ENDPOINT=http://host.docker.internal:8545 PORT=26000 docker-compose up` will launch Sirato explorer on port `26000`, and it will be accessible via `http://<custom_host>:26000` instead of `http://<custom_host>`

This is needed so that Besu users can launch sirato on desired ports as required in this [Hyperledger Besu Docs](https://github.com/hyperledger/besu-docs/pull/1252)
